### PR TITLE
Support disable to include callstack tree.

### DIFF
--- a/requests/src/main/java/com/megaease/easeagent/requests/AsyncLogReporter.java
+++ b/requests/src/main/java/com/megaease/easeagent/requests/AsyncLogReporter.java
@@ -27,9 +27,10 @@ class AsyncLogReporter implements Reporter {
     private final String system;
     private final String application;
     private final String type;
+    private final boolean callstack;
     private final Logger logger;
 
-    AsyncLogReporter(Logger logger, int capacity, String hostipv4, String hostname, String system, String application, String type) {
+    AsyncLogReporter(Logger logger, int capacity, String hostipv4, String hostname, String system, String application, String type, boolean callstack) {
         this.logger = logger;
         this.queue = new ArrayBlockingQueue<TracedRequestEvent>(capacity);
         this.hostipv4 = hostipv4;
@@ -37,6 +38,7 @@ class AsyncLogReporter implements Reporter {
         this.system = system;
         this.application = application;
         this.type = type;
+        this.callstack = callstack;
 
         Executors.newSingleThreadExecutor(new NamedDaemonThreadFactory("easeagent-requests-report")).submit(new LoggingDaemon());
     }
@@ -82,12 +84,12 @@ class AsyncLogReporter implements Reporter {
 
             @Override
             public Context getCallStackJson() {
-                return context;
+                return callstack ? context : Context.empty();
             }
 
             @Override
             public boolean getContainsCallTree() {
-                return context.getChildren().size() > 0;
+                return !getCallStackJson().getChildren().isEmpty();
             }
 
             @Override

--- a/requests/src/main/java/com/megaease/easeagent/requests/Context.java
+++ b/requests/src/main/java/com/megaease/easeagent/requests/Context.java
@@ -45,6 +45,10 @@ class Context {
         return frame.<Context>context().stop(frame.children());
     }
 
+    static Context empty() {
+        return new Context(null, null, null, false, 0,0);
+    }
+
     private static Supplier<Context> supplier(final Class<?> aClass, final String method) {
         return new Supplier<Context>() {
             @Override

--- a/requests/src/main/java/com/megaease/easeagent/requests/Provider.java
+++ b/requests/src/main/java/com/megaease/easeagent/requests/Provider.java
@@ -23,7 +23,7 @@ abstract class Provider {
     @Injection.Bean
     public Reporter reporter() {
         return new AsyncLogReporter(LoggerFactory.getLogger(reporter_name()), reporter_queue_capacity(), hostipv4(),
-                                    hostname(), system(), application(), type());
+                                    hostname(), system(), application(), type(), callstack());
     }
 
     @Configurable.Item
@@ -34,6 +34,11 @@ abstract class Provider {
     @Configurable.Item
     String type() {
         return "http_request";
+    }
+
+    @Configurable.Item
+    boolean callstack() {
+        return false;
     }
 
     @Configurable.Item

--- a/requests/src/test/java/com/megaease/easeagent/requests/AsyncLogReporterTest.java
+++ b/requests/src/test/java/com/megaease/easeagent/requests/AsyncLogReporterTest.java
@@ -20,11 +20,11 @@ import static org.mockito.Mockito.verify;
 public class AsyncLogReporterTest {
     final Logger logger = mock(Logger.class);
     final CallTrace trace = new CallTrace();
-    final AsyncLogReporter reporter = new AsyncLogReporter(logger, 1, "ip", "hostname", "system", "application", "type");
     final Map<String, String> map = Collections.singletonMap("k", "v");
 
     @Test
     public void should_not_contain_call_tree() throws Exception {
+        final AsyncLogReporter reporter = new AsyncLogReporter(logger, 1, "ip", "hostname", "system", "application", "type", false);
         Context.pushIfRootCall(trace, HttpServlet.class, "service");
 
         final Context root = Context.pop(trace);
@@ -42,6 +42,7 @@ public class AsyncLogReporterTest {
 
     @Test
     public void should_contain_call_tree() throws Exception {
+        final AsyncLogReporter reporter = new AsyncLogReporter(logger, 1, "ip", "hostname", "system", "application", "type", true);
         Context.pushIfRootCall(trace, HttpServlet.class, "service");
 
         Context.forkCall(trace, String.class, "toString");


### PR DESCRIPTION
Callstack will be excluded as default in this new version.  

Configuration as below, callstack will be included:

```
requests {
  report = ${host.info} {
    callstack = true
  }
}

```