### PR TITLE
fix bug: can not get agent.properties from easeagent.jar

### DIFF
--- a/build/src/assembly/src.xml
+++ b/build/src/assembly/src.xml
@@ -12,7 +12,7 @@
             <outputDirectory/>
             <includes>
                 <include>git.properties</include>
-                <include>application.conf</include>
+                <include>agent.properties</include>
                 <include>log4j2.xml</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
User run cmd: ` jar xf  easeagent.jar agent.properties`,  can not get agent.properties