### PR TITLE
[typo] fix public identifier for interface function

### DIFF
--- a/config/src/main/java/com/megaease/easeagent/config/Config.java
+++ b/config/src/main/java/com/megaease/easeagent/config/Config.java
@@ -22,21 +22,21 @@ import java.util.Set;
 
 public interface Config {
 
-    public boolean hasPath(String path);
+    boolean hasPath(String path);
 
-    public String getString(String name);
+    String getString(String name);
 
-    public Integer getInt(String name);
+    Integer getInt(String name);
 
-    public Boolean getBoolean(String name);
+    Boolean getBoolean(String name);
 
-    public Double getDouble(String name);
+    Double getDouble(String name);
 
-    public Long getLong(String name);
+    Long getLong(String name);
 
-    public List<String> getStringList(String name);
+    List<String> getStringList(String name);
 
-    public Runnable addChangeListener(ConfigChangeListener listener);
+    Runnable addChangeListener(ConfigChangeListener listener);
 
     Set<String> keySet();
 }

--- a/config/src/main/java/com/megaease/easeagent/config/ConfigChangeListener.java
+++ b/config/src/main/java/com/megaease/easeagent/config/ConfigChangeListener.java
@@ -20,5 +20,5 @@ package com.megaease.easeagent.config;
 import java.util.List;
 
 public interface ConfigChangeListener {
-    public void onChange(List<ChangeItem> list);
+    void onChange(List<ChangeItem> list);
 }


### PR DESCRIPTION
there is no need to add `public` identifier for interface function in java8