### PR TITLE
add tenant_id in tracing and metrics

### DIFF
--- a/build/src/main/resources/agent.properties
+++ b/build/src/main/resources/agent.properties
@@ -1,5 +1,6 @@
 name=unknown-service
 system=unknown-system
+tenant_id=99999999
 
 ### http server
 # When the enabled value = false, agent will not start the http server

--- a/common/src/main/java/com/megaease/easeagent/common/AdditionalAttributes.java
+++ b/common/src/main/java/com/megaease/easeagent/common/AdditionalAttributes.java
@@ -40,16 +40,17 @@ public class AdditionalAttributes {
     private final static Logger LOGGER = LoggerFactory.getLogger(AdditionalAttributes.class);
     public final Map<String, Object> attributes;
 
-    public AdditionalAttributes(String serviceName, String systemName) {
+    public AdditionalAttributes(String serviceName, String systemName, String tenantId) {
         attributes = new HashMap<>();
         attributes.put("host_ipv4", getHostIpv4());
         attributes.put("service", serviceName);
         attributes.put("system", systemName);
         attributes.put("host_name", getHostName());
+        attributes.put("tenant_id", tenantId);
     }
 
     public AdditionalAttributes(String serviceName) {
-        this(serviceName, "none");
+        this(serviceName, "none", "99999999");
     }
 
     static String getHostIpV4(Enumeration<NetworkInterface> networkInterfaces) throws Exception {

--- a/common/src/main/java/com/megaease/easeagent/common/jdbc/MD5DictionaryItem.java
+++ b/common/src/main/java/com/megaease/easeagent/common/jdbc/MD5DictionaryItem.java
@@ -42,6 +42,8 @@ public class MD5DictionaryItem {
 
     private String system;
 
+    private String tenantId;
+
     private String type;
 
     private String tags;

--- a/config/src/main/java/com/megaease/easeagent/config/ConfigConst.java
+++ b/config/src/main/java/com/megaease/easeagent/config/ConfigConst.java
@@ -26,6 +26,7 @@ public interface ConfigConst {
     String SYSTEM_NAME = "system";
     String OBSERVABILITY = "observability";
     String GLOBAL_CANARY_LABELS = "globalCanaryHeaders";
+    String TENANT_ID = "tenant_id";
 
     static String join(String... texts) {
         return String.join(DELIMITER, texts);

--- a/metrics/src/main/java/com/megaease/easeagent/metrics/converter/MetricsAdditionalAttributes.java
+++ b/metrics/src/main/java/com/megaease/easeagent/metrics/converter/MetricsAdditionalAttributes.java
@@ -30,16 +30,20 @@ public class MetricsAdditionalAttributes implements Supplier<Map<String, Object>
     private volatile Map<String, Object> additionalAttributes;
     private volatile String serviceName = "";
     private volatile String systemName = "";
+    private volatile String tenantId = "";
 
     public MetricsAdditionalAttributes(Config config) {
         ConfigUtils.bindProp(ConfigConst.SERVICE_NAME, config, Config::getString, v -> {
             this.serviceName = v;
-            this.additionalAttributes = new AdditionalAttributes(this.serviceName, this.systemName).getAdditionalAttributes();
         });
         ConfigUtils.bindProp(ConfigConst.SYSTEM_NAME, config, Config::getString, v -> {
             this.systemName = v;
-            this.additionalAttributes = new AdditionalAttributes(this.serviceName, this.systemName).getAdditionalAttributes();
         });
+
+        ConfigUtils.bindProp(ConfigConst.TENANT_ID, config, Config::getString, v -> {
+            this.tenantId = v;
+        });
+        this.additionalAttributes = new AdditionalAttributes(this.serviceName, this.systemName, this.tenantId).getAdditionalAttributes();
     }
 
     @Override

--- a/report/src/main/java/com/megaease/easeagent/report/trace/TraceReport.java
+++ b/report/src/main/java/com/megaease/easeagent/report/trace/TraceReport.java
@@ -83,6 +83,7 @@ public class TraceReport {
         GlobalExtrasSupplier extrasSupplier = new GlobalExtrasSupplier() {
             final AutoRefreshConfigItem<String> serviceName = new AutoRefreshConfigItem<>(configs, ConfigConst.SERVICE_NAME, Config::getString);
             final AutoRefreshConfigItem<String> systemName = new AutoRefreshConfigItem<>(configs, ConfigConst.SYSTEM_NAME, Config::getString);
+            final AutoRefreshConfigItem<String> tenantId = new AutoRefreshConfigItem<>(configs, ConfigConst.TENANT_ID, Config::getString);
 
             @Override
             public String service() {
@@ -92,6 +93,11 @@ public class TraceReport {
             @Override
             public String system() {
                 return systemName.getValue();
+            }
+
+            @Override
+            public String tenantId() {
+                return tenantId.getValue();
             }
         };
         SDKAsyncReporter reporter = SDKAsyncReporter.

--- a/report/src/main/java/zipkin2/internal/AgentV2SpanGlobalWriter.java
+++ b/report/src/main/java/zipkin2/internal/AgentV2SpanGlobalWriter.java
@@ -34,6 +34,7 @@ public class AgentV2SpanGlobalWriter implements WriteBuffer.Writer<Span> {
     final String typeFieldName = ",\"type\":\"";
     final String serviceFieldName = ",\"service\":\"";
     final String systemFieldName = ",\"system\":\"";
+    final String tenantIdFieldName = ",\"tenant_id\":\"";
 
     public AgentV2SpanGlobalWriter(String type, GlobalExtrasSupplier extras, TraceProps tp) {
         this.type = type;
@@ -61,6 +62,13 @@ public class AgentV2SpanGlobalWriter implements WriteBuffer.Writer<Span> {
                 mutableInt.add(systemFieldName.length() + 1);
                 mutableInt.add(JsonEscaper.jsonEscapedSizeInBytes(tmpSystem));
             }
+
+            String tmpTenantId = this.extras.tenantId();
+            if (TextUtils.hasText(tmpTenantId)) {
+                mutableInt.add(tenantIdFieldName.length() + 1);
+                mutableInt.add(JsonEscaper.jsonEscapedSizeInBytes(tmpTenantId));
+            }
+
         });
         return mutableInt.intValue();
     }
@@ -83,6 +91,13 @@ public class AgentV2SpanGlobalWriter implements WriteBuffer.Writer<Span> {
             if (TextUtils.hasText(tmpSystem)) {
                 buffer.writeAscii(systemFieldName);
                 buffer.writeUtf8(JsonEscaper.jsonEscape(tmpSystem));
+                buffer.writeByte(34);
+            }
+
+            String tmpTenantId = this.extras.tenantId();
+            if (TextUtils.hasText(tmpTenantId)) {
+                buffer.writeAscii(tenantIdFieldName);
+                buffer.writeUtf8(JsonEscaper.jsonEscape(tmpTenantId));
                 buffer.writeByte(34);
             }
         });

--- a/report/src/main/java/zipkin2/internal/AgentV2SpanWriter.java
+++ b/report/src/main/java/zipkin2/internal/AgentV2SpanWriter.java
@@ -40,6 +40,11 @@ public class AgentV2SpanWriter implements WriteBuffer.Writer<Span> {
             public String system() {
                 return "";
             }
+
+            @Override
+            public String tenantId() {
+                return "";
+            }
         }, null);
     }
 

--- a/report/src/main/java/zipkin2/internal/GlobalExtrasSupplier.java
+++ b/report/src/main/java/zipkin2/internal/GlobalExtrasSupplier.java
@@ -21,4 +21,6 @@ public interface GlobalExtrasSupplier {
     String service();
 
     String system();
+
+    String tenantId();
 }

--- a/zipkin/src/main/java/com/megaease/easeagent/zipkin/CustomTagsSpanHandler.java
+++ b/zipkin/src/main/java/com/megaease/easeagent/zipkin/CustomTagsSpanHandler.java
@@ -27,9 +27,13 @@ public class CustomTagsSpanHandler extends SpanHandler {
     public static final String TAG_INSTANCE = "i";
     private final String instance;
     private final Supplier<String> serviceName;
+    private final Supplier<String> systemName;
+    private final Supplier<String> tenantId;
 
-    public CustomTagsSpanHandler(Supplier<String> serviceName, String instance) {
+    public CustomTagsSpanHandler(Supplier<String> serviceName, Supplier<String> systemName, Supplier<String> tenantId, String instance) {
         this.serviceName = serviceName;
+        this.systemName = systemName;
+        this.tenantId = tenantId;
         this.instance = instance;
     }
 


### PR DESCRIPTION
# Background

There are 2 basic attributes for metrics and tracing isolation and navigation factors on the web console. 
1. service ( ${spring.service.name} )
2. system( ${project.id})

# Requirement

Add a new attribute for the multi-tenant solution:
1. tenant_id( ${project.tenant_id})
