### PR TITLE
 Optimize AgentByteBoundedQueue to avoid excessive latency in concurrent scenarios

### DIFF
--- a/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
+++ b/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
@@ -18,8 +18,10 @@ import lombok.Data;
 
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntUnaryOperator;
 
 /**
  * Multi-producer, multi-consumer queue that is bounded by both count and size.
@@ -27,13 +29,12 @@ import java.util.concurrent.atomic.LongAdder;
  * <p>This is similar to {@link java.util.concurrent.ArrayBlockingQueue} in implementation.
  */
 public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
-    private final LinkedTransferQueue<DataWrapper<S>> queue = new LinkedTransferQueue<>();
+
+    private final AtomicReference<State<S>> state = new AtomicReference<>(new State<>());
 
     private final int maxSize;
 
     private final int maxBytes;
-
-    private final AtomicLong sizeInBytes = new AtomicLong(0L);
 
     private final LongAdder loseCounter = new LongAdder();
 
@@ -44,28 +45,30 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
 
     @Override
     public boolean offer(S next, int nextSizeInBytes) {
-        if (maxSize == queue.size()) {
+        State<S> sState = state.get();
+        if (maxSize == sState.getQueueSize()) {
             loseCounter.increment();
             return false;
         }
-        if (sizeInBytes.updateAndGet(pre -> pre + nextSizeInBytes) > maxBytes) {
+        if (sState.updateAndGet(pre -> pre + nextSizeInBytes) > maxBytes) {
             loseCounter.increment();
-            sizeInBytes.updateAndGet(pre -> pre - nextSizeInBytes);
+            sState.updateAndGet(pre -> pre - nextSizeInBytes);
             return false;
         }
-        queue.offer(new DataWrapper<>(next, nextSizeInBytes));
+        sState.offer(new DataWrapper<>(next, nextSizeInBytes));
         return true;
     }
 
     int doDrain(WithSizeConsumer<S> consumer, DataWrapper<S> firstPoll) {
+        State<S> sState = state.get();
         int drainedCount = 0;
         int drainedSizeInBytes = 0;
         DataWrapper<S> next = null;
-        while (drainedCount < queue.size()) {
+        while (drainedCount < sState.getQueueSize()) {
             if (next == null) {
                 next = firstPoll;
             } else {
-                next = queue.poll();
+                next = sState.poll();
             }
             if (next == null) break;
             int nextSizeInBytes = next.getSizeInBytes();
@@ -77,14 +80,15 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
             }
         }
         final int updateValue = drainedSizeInBytes;
-        sizeInBytes.updateAndGet(pre -> pre - updateValue);
+        sState.updateAndGet(pre -> pre - updateValue);
         return drainedCount;
     }
 
     public int drainTo(WithSizeConsumer<S> consumer, long nanosTimeout) {
+        State<S> sState = state.get();
         DataWrapper<S> firstPoll;
         try {
-            firstPoll = queue.poll(nanosTimeout, TimeUnit.NANOSECONDS);
+            firstPoll = sState.poll(nanosTimeout, TimeUnit.NANOSECONDS);
         } catch (InterruptedException e) {
             return 0;
         }
@@ -95,20 +99,15 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
     }
 
     public int getCount() {
-        return queue.size();
+        return state.get().getQueueSize();
     }
 
     public int getSizeInBytes() {
-        return sizeInBytes.intValue();
+        return state.get().getSizeInBytes();
     }
 
     public int clear() {
-        if (sizeInBytes.getAndUpdate(pre -> 0) > 0) {
-            int result = queue.size();
-            queue.clear();
-            return result;
-        }
-        return 0;
+        return state.getAndSet(new State<>()).getQueueSize();
     }
 
     public long getLoseCount() {
@@ -122,5 +121,38 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
 
         private final int sizeInBytes;
     }
+
+    private static class State<S> {
+
+        private final LinkedTransferQueue<DataWrapper<S>> queue = new LinkedTransferQueue<>();
+
+        private final AtomicInteger sizeInBytes = new AtomicInteger(0);
+
+        public int getQueueSize() {
+            return queue.size();
+        }
+
+        public DataWrapper<S> poll() {
+            return queue.poll();
+        }
+
+        public boolean offer(DataWrapper<S> data) {
+            return queue.offer(data);
+        }
+
+        public DataWrapper<S> poll(long nanosTimeout, TimeUnit unit) throws InterruptedException {
+            return queue.poll(nanosTimeout, unit);
+        }
+
+        public long updateAndGet(IntUnaryOperator updateFunction) {
+            return sizeInBytes.getAndUpdate(updateFunction);
+        }
+
+        public int getSizeInBytes() {
+            return sizeInBytes.get();
+        }
+
+    }
+
 }
 

--- a/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
+++ b/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
@@ -62,7 +62,8 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
         int drainedCount = 0;
         int drainedSizeInBytes = 0;
         DataWrapper<S> next = null;
-        while (drainedCount < queue.size()) {
+        int count = queue.size() + 1;
+        while (drainedCount < count) {
             if (next == null) {
                 next = firstPoll;
             } else {

--- a/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
+++ b/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
@@ -106,10 +106,12 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
     public int clear() {
         DataWrapper<S> data;
         int result = 0;
+        int removeBytes = 0;
         while ((data = queue.poll()) != null) {
-            sizeInBytes.addAndGet(data.getSizeInBytes() * -1);
+            removeBytes += data.getSizeInBytes();
             result++;
         }
+        sizeInBytes.addAndGet(removeBytes * -1);
         return result;
     }
 

--- a/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
+++ b/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
@@ -107,7 +107,7 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
         DataWrapper<S> data;
         int result = 0;
         while ((data = queue.poll()) != null) {
-            sizeInBytes.addAndGet(data.getSizeInBytes());
+            sizeInBytes.addAndGet(data.getSizeInBytes() * -1);
             result++;
         }
         return result;

--- a/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
+++ b/report/src/main/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueue.java
@@ -145,7 +145,7 @@ public final class AgentByteBoundedQueue<S> implements WithSizeConsumer<S> {
         }
 
         public long updateAndGet(IntUnaryOperator updateFunction) {
-            return sizeInBytes.getAndUpdate(updateFunction);
+            return sizeInBytes.updateAndGet(updateFunction);
         }
 
         public int getSizeInBytes() {

--- a/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
+++ b/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
@@ -58,7 +58,7 @@ public class AgentByteBoundedQueueTest {
     @Test
     public void multiThreadProductConsumerTest() throws InterruptedException {
         AgentByteBoundedQueue<String> queue = new AgentByteBoundedQueue<>(100, 100);
-        int threadCount = Runtime.getRuntime().availableProcessors();
+        int threadCount = 10;
         final CountDownLatch latch = new CountDownLatch(threadCount);
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         SynchronousQueue<Object> synchronousQueue = new SynchronousQueue<>();
@@ -101,7 +101,7 @@ public class AgentByteBoundedQueueTest {
     @Test
     public void testDatNotLostOnDrainToFail() throws Exception {
         AgentByteBoundedQueue<String> queue = new AgentByteBoundedQueue<>(1000, 1000);
-        int threadCount = Runtime.getRuntime().availableProcessors();
+        int threadCount = 10;
         final CountDownLatch latch = new CountDownLatch(threadCount);
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         SynchronousQueue<Object> synchronousQueue = new SynchronousQueue<>();

--- a/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
+++ b/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
@@ -38,18 +38,18 @@ public class AgentByteBoundedQueueTest {
             queue.offer("test" + i, 1);
         }
         result = queue.drainTo(consumer, TimeUnit.SECONDS.toNanos(1));
-        Assert.assertEquals("The normal result should be 5..", 5, result);
-        Assert.assertEquals("There should be half the elements in the queue.", 5, queue.getCount());
-        Assert.assertEquals("The number of bytes of the remaining data in the queue should be 5", 5, queue.getSizeInBytes());
+        Assert.assertEquals("The normal result should be 10..", 10, result);
+        Assert.assertEquals("The queue should be empty now.", 0, queue.getCount());
+        Assert.assertEquals("The number of bytes of the remaining data in the queue should be 0", 0, queue.getSizeInBytes());
         //3. add 100 object and then consumer object
         queue = new AgentByteBoundedQueue<>(10, 100);
         for (int i = 0; i < 100; i++) {
             queue.offer("test" + i, 1);
         }
         result = queue.drainTo(consumer, TimeUnit.SECONDS.toNanos(1));
-        Assert.assertEquals("Teh normal result should be 5..", 5, result);
-        Assert.assertEquals("There should be half the elements in the queue.", 5, queue.getCount());
-        Assert.assertEquals("The number of bytes of the remaining data in the queue should be 5", 5, queue.getSizeInBytes());
+        Assert.assertEquals("Teh normal result should be 10..", 10, result);
+        Assert.assertEquals("The queue should be empty now.", 0, queue.getCount());
+        Assert.assertEquals("The number of bytes of the remaining data in the queue should be 0", 0, queue.getSizeInBytes());
         Assert.assertEquals("The amount of data lost should be 90.", 90, queue.getLoseCount());
     }
 

--- a/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
+++ b/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
@@ -1,0 +1,56 @@
+package com.megaease.easeagent.report.async.zipkin;
+
+import com.megaease.easeagent.report.plugin.NoOpEncoder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class AgentByteBoundedQueueTest {
+
+    private final AgentByteBoundedQueue<String> queue = new AgentByteBoundedQueue<>(10, 100);
+
+    @Test
+    public void offer() {
+        // 1. 测试普通offer
+        // 2. 测试超过maxSize
+        // 3. 测试超过maxBytes
+        queue.offer("abc", 5);
+        Assert.assertEquals("getCount should be 1", 1, queue.getCount());
+        for (int i = 0; i < 9; i++) {
+            queue.offer("abc", i);
+        }
+        Assert.assertFalse(
+            "The last piece of data should not be inserted.", queue.offer("last", 1));
+        queue.clear();
+        queue.offer("abc", 5);
+        Assert.assertFalse("Beyond maxBytes, data should not be inserted.", queue.offer("last", 100));
+    }
+
+    @Test
+    public void drainTo() {
+        //1. 测试队列为空时，直接超时并返回0。
+        //2. 测试正常情况
+        AgentBufferNextMessage<String> message = AgentBufferNextMessage.create(new NoOpEncoder<>(), 100, TimeUnit.SECONDS.toNanos(1));
+        int result = queue.drainTo(message, TimeUnit.SECONDS.toNanos(1));
+        Assert.assertEquals("The queue is empty and the result should be 0 normally.", 0, result);
+        for (int i = 0; i < 10; i++) {
+            queue.offer("test" + i, 1);
+        }
+        result = queue.drainTo(message, TimeUnit.SECONDS.toNanos(1));
+        Assert.assertEquals("The normal result should be 5..", 5, result);
+        Assert.assertEquals("There should be half the elements in the queue.", 5, queue.getCount());
+        Assert.assertEquals("The number of bytes of the remaining data in the queue should be 5", 5, queue.getSizeInBytes());
+    }
+
+    @Test
+    public void clear() {
+        for (int i = 0; i < 10; i++) {
+            queue.offer("test" + i, 1);
+        }
+        Assert.assertEquals("The queue size should be 10", 10, queue.getCount());
+        queue.clear();
+        Assert.assertEquals("The queue size should be 0", 0, queue.getCount());
+        Assert.assertEquals("The number of bytes of data in the queue should be 0", 0, queue.getSizeInBytes());
+    }
+}

--- a/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
+++ b/report/src/test/java/com/megaease/easeagent/report/async/zipkin/AgentByteBoundedQueueTest.java
@@ -8,20 +8,20 @@ import java.util.concurrent.TimeUnit;
 
 public class AgentByteBoundedQueueTest {
 
-    private final AgentByteBoundedQueue<String> queue = new AgentByteBoundedQueue<>(10, 100);
+    private AgentByteBoundedQueue<String> queue = new AgentByteBoundedQueue<>(10, 100);
 
     @Test
     public void offer() {
-        // 1. 测试普通offer
-        // 2. 测试超过maxSize
-        // 3. 测试超过maxBytes
+        // 1. Test normal offer execution
         queue.offer("abc", 5);
         Assert.assertEquals("getCount should be 1", 1, queue.getCount());
+        // 2. Test situations that exceed the MaxSize
         for (int i = 0; i < 9; i++) {
             queue.offer("abc", i);
         }
         Assert.assertFalse(
             "The last piece of data should not be inserted.", queue.offer("last", 1));
+        // 3. Test situations that exceed the MaxBytes
         queue.clear();
         queue.offer("abc", 5);
         Assert.assertFalse("Beyond maxBytes, data should not be inserted.", queue.offer("last", 100));
@@ -29,18 +29,28 @@ public class AgentByteBoundedQueueTest {
 
     @Test
     public void drainTo() {
-        //1. 测试队列为空时，直接超时并返回0。
-        //2. 测试正常情况
-        AgentBufferNextMessage<String> message = AgentBufferNextMessage.create(new NoOpEncoder<>(), 100, TimeUnit.SECONDS.toNanos(1));
-        int result = queue.drainTo(message, TimeUnit.SECONDS.toNanos(1));
+        //1. When the test team is listed as empty, it times out and returns 0.
+        AgentBufferNextMessage<String> consumer = AgentBufferNextMessage.create(new NoOpEncoder<>(), 100, TimeUnit.SECONDS.toNanos(1));
+        int result = queue.drainTo(consumer, TimeUnit.SECONDS.toNanos(1));
         Assert.assertEquals("The queue is empty and the result should be 0 normally.", 0, result);
+        //2. Normal performance of the test
         for (int i = 0; i < 10; i++) {
             queue.offer("test" + i, 1);
         }
-        result = queue.drainTo(message, TimeUnit.SECONDS.toNanos(1));
+        result = queue.drainTo(consumer, TimeUnit.SECONDS.toNanos(1));
         Assert.assertEquals("The normal result should be 5..", 5, result);
         Assert.assertEquals("There should be half the elements in the queue.", 5, queue.getCount());
         Assert.assertEquals("The number of bytes of the remaining data in the queue should be 5", 5, queue.getSizeInBytes());
+        //3. add 100 object and then consumer object
+        queue = new AgentByteBoundedQueue<>(10, 100);
+        for (int i = 0; i < 100; i++) {
+            queue.offer("test" + i, 1);
+        }
+        result = queue.drainTo(consumer, TimeUnit.SECONDS.toNanos(1));
+        Assert.assertEquals("Teh normal result should be 5..", 5, result);
+        Assert.assertEquals("There should be half the elements in the queue.", 5, queue.getCount());
+        Assert.assertEquals("The number of bytes of the remaining data in the queue should be 5", 5, queue.getSizeInBytes());
+        Assert.assertEquals("The amount of data lost should be 90.", 90, queue.getLoseCount());
     }
 
     @Test


### PR DESCRIPTION
We found that the difference in latency between using and not using the easeagent was relatively large, as observed by the flame chart, and finally located that the reason was because com.megaease.easeagent.report.async.zipkin.AgentByteBoundedQueue# offer method, it will call the ReentrantLock#lock method at the entry point, and it will get stuck here in a high concurrency scenario.
I've seen others on github who have encountered the same problem: https://github.com/openzipkin/zipkin-reporter-java/issues/101