### PR TITLE
fix CVE-2022-25857 for snakeyaml & fix CVE-2020-36518 for jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <version.jsr305>3.0.2</version.jsr305>
         <version.lombok>1.18.20</version.lombok>
         <version.config>1.2.1</version.config>
-        <version.jackson>2.12.1</version.jackson>
+        <version.jackson>2.12.7</version.jackson>
         <version.servlet>3.1.0</version.servlet>
         <version.brave>5.13.3</version.brave>
         <version.otel>1.12.0</version.otel>
@@ -84,7 +84,7 @@
         <version.prometheus>0.10.0</version.prometheus>
         <version.sparkjava>2.9.2</version.sparkjava>
         <version.httpclient>4.5.13</version.httpclient>
-        <version.yaml>1.30</version.yaml>
+        <version.yaml>1.31</version.yaml>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
CVE-2022-25857——Minimum fix version：1.31
CVE-2020-36518——Minimum fix version：2.12.6.1（Something wrong with 2.12.6.1 in my local machine, so i choose 2.12.7）