### PR TITLE
fix: Failed to collect Dubbo and Motan plugin metrics using Prometheus

### DIFF
--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/AlibabaDubboCtxUtils.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/AlibabaDubboCtxUtils.java
@@ -24,12 +24,14 @@ import com.megaease.easeagent.plugin.utils.common.JsonUtil;
 import java.util.concurrent.Future;
 
 import static com.alibaba.dubbo.common.Constants.*;
-import static com.megaease.easeagent.plugin.dubbo.DubboTags.RESULT;
+import static com.megaease.easeagent.plugin.dubbo.DubboTraceTags.RESULT;
 
 public class AlibabaDubboCtxUtils {
 	public static final String CLIENT_REQUEST_CONTEXT = AlibabaDubboCtxUtils.class.getName() + ".CLIENT_REQUEST_CONTEXT";
 	private static final String SERVICE_REQUEST_CONTEXT = AlibabaDubboCtxUtils.class.getName() + ".SERVICE_REQUEST_CONTEXT";
 	public static final String METRICS_SERVICE_NAME = AlibabaDubboCtxUtils.class.getName() + ".METRICS_SERVICE_NAME";
+	public static final String BEGIN_TIME = AlibabaDubboCtxUtils.class.getName() + ".BEGIN_TIME";
+
 
 	public static void initSpan(MethodInfo methodInfo, Context context) {
 		Invoker<?> invoker = (Invoker<?>) methodInfo.getArgs()[0];
@@ -52,12 +54,12 @@ public class AlibabaDubboCtxUtils {
 			span.remoteIpAndPort(rpcContext.getRemoteHost(), rpcContext.getRemotePort());
 
 			String argsList = DubboBaseInterceptor.DUBBO_TRACE_CONFIG.argsCollectEnabled() ? JsonUtil.toJson(invocation.getArguments()) : null;
-			span.tag(DubboTags.CLIENT_APPLICATION.name, applicationName);
-			span.tag(DubboTags.GROUP.name, groupName);
-			span.tag(DubboTags.SERVICE.name, requestUrl.getPath());
-			span.tag(DubboTags.METHOD.name, method(invocation));
-			span.tag(DubboTags.SERVICE_VERSION.name, version);
-			span.tag(DubboTags.ARGS.name, argsList);
+			span.tag(DubboTraceTags.CLIENT_APPLICATION.name, applicationName);
+			span.tag(DubboTraceTags.GROUP.name, groupName);
+			span.tag(DubboTraceTags.SERVICE.name, requestUrl.getPath());
+			span.tag(DubboTraceTags.METHOD.name, method(invocation));
+			span.tag(DubboTraceTags.SERVICE_VERSION.name, version);
+			span.tag(DubboTraceTags.ARGS.name, argsList);
 
 			context.put(CLIENT_REQUEST_CONTEXT, requestContext);
 		} else {
@@ -69,7 +71,7 @@ public class AlibabaDubboCtxUtils {
 			span.name(alibabaDubboServerRequest.name());
 			span.remoteServiceName(ConfigConst.Namespace.DUBBO);
 			span.remoteIpAndPort(rpcContext.getRemoteHost(), rpcContext.getRemotePort());
-			span.tag(DubboTags.SERVER_APPLICATION.name, applicationName);
+			span.tag(DubboTraceTags.SERVER_APPLICATION.name, applicationName);
 
 			context.put(SERVICE_REQUEST_CONTEXT, requestContext);
 		}

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/ApacheDubboCtxUtils.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/ApacheDubboCtxUtils.java
@@ -24,6 +24,7 @@ public class ApacheDubboCtxUtils {
     private static final String CLIENT_REQUEST_CONTEXT = ApacheDubboCtxUtils.class.getName() + ".CLIENT_REQUEST_CONTEXT";
     private static final String SERVICE_REQUEST_CONTEXT = ApacheDubboCtxUtils.class.getName() + ".SERVICE_REQUEST_CONTEXT";
     public static final String METRICS_SERVICE_NAME = ApacheDubboCtxUtils.class.getName() + ".METRICS_SERVICE_NAME";
+    public static final String BEGIN_TIME = ApacheDubboCtxUtils.class.getName() + ".BEGIN_TIME";
     //dubbo get metadata interface
     public static final String METADATA_INTERFACE = "org.apache.dubbo.metadata.MetadataService";
 
@@ -60,12 +61,12 @@ public class ApacheDubboCtxUtils {
             span.remoteIpAndPort(requestUrl.getIp(), requestUrl.getPort());
 
             String argsList = DubboBaseInterceptor.DUBBO_TRACE_CONFIG.argsCollectEnabled() ? JsonUtil.toJson(invocation.getArguments()) : null;
-            span.tag(DubboTags.CLIENT_APPLICATION.name, applicationName);
-            span.tag(DubboTags.GROUP.name, groupName);
-            span.tag(DubboTags.SERVICE.name, requestUrl.getPath());
-            span.tag(DubboTags.METHOD.name, method(invocation));
-            span.tag(DubboTags.SERVICE_VERSION.name, version);
-            span.tag(DubboTags.ARGS.name, argsList);
+            span.tag(DubboTraceTags.CLIENT_APPLICATION.name, applicationName);
+            span.tag(DubboTraceTags.GROUP.name, groupName);
+            span.tag(DubboTraceTags.SERVICE.name, requestUrl.getPath());
+            span.tag(DubboTraceTags.METHOD.name, method(invocation));
+            span.tag(DubboTraceTags.SERVICE_VERSION.name, version);
+            span.tag(DubboTraceTags.ARGS.name, argsList);
 
             context.put(CLIENT_REQUEST_CONTEXT, requestContext);
         } else {
@@ -77,7 +78,7 @@ public class ApacheDubboCtxUtils {
             span.name(apacheDubboServerRequest.name());
             span.remoteServiceName(CommonConstants.DUBBO);
             span.remoteIpAndPort(rpcContext.getRemoteHost(), rpcContext.getRemotePort());
-            span.tag(DubboTags.SERVER_APPLICATION.name, applicationName);
+            span.tag(DubboTraceTags.SERVER_APPLICATION.name, applicationName);
 
             context.put(SERVICE_REQUEST_CONTEXT, requestContext);
         }
@@ -113,7 +114,7 @@ public class ApacheDubboCtxUtils {
                 span.error(result.getException());
             } else {
                 if (dubboTraceConfig.resultCollectEnabled() && result.getValue() != null) {
-                    span.tag(DubboTags.RESULT.name, JsonUtil.toJson(result.getValue()));
+                    span.tag(DubboTraceTags.RESULT.name, JsonUtil.toJson(result.getValue()));
                 }
             }
         }

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/DubboMetricTags.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/DubboMetricTags.java
@@ -1,0 +1,14 @@
+package com.megaease.easeagent.plugin.dubbo;
+
+public enum DubboMetricTags {
+	CATEGORY("application"),
+	TYPE("dubbo"),
+	LABEL_NAME("interface"),
+	;
+
+	public final String name;
+
+	DubboMetricTags(String name) {
+		this.name = name;
+	}
+}

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/DubboTraceTags.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/DubboTraceTags.java
@@ -1,6 +1,6 @@
 package com.megaease.easeagent.plugin.dubbo;
 
-public enum DubboTags {
+public enum DubboTraceTags {
 	SERVICE("dubbo.service"),
 	METHOD("dubbo.method"),
 	SERVICE_VERSION("dubbo.service.version"),
@@ -13,7 +13,7 @@ public enum DubboTags {
 
 	public final String name;
 
-	DubboTags(String name) {
+	DubboTraceTags(String name) {
 		this.name = name;
 	}
 }

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/DubboBaseMetricsInterceptor.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/DubboBaseMetricsInterceptor.java
@@ -1,14 +1,14 @@
 package com.megaease.easeagent.plugin.dubbo.interceptor.metrics;
 
-import com.megaease.easeagent.plugin.api.config.ConfigConst;
 import com.megaease.easeagent.plugin.api.config.IPluginConfig;
 import com.megaease.easeagent.plugin.api.metric.ServiceMetricRegistry;
 import com.megaease.easeagent.plugin.api.metric.name.Tags;
+import com.megaease.easeagent.plugin.dubbo.DubboMetricTags;
 import com.megaease.easeagent.plugin.enums.Order;
 import com.megaease.easeagent.plugin.interceptor.Interceptor;
 
 public abstract class DubboBaseMetricsInterceptor implements Interceptor {
-    protected static volatile DubboMetrics DUBBO_METRICS;
+    public static volatile DubboMetrics DUBBO_METRICS;
 
     @Override
     public String getType() {
@@ -22,7 +22,8 @@ public abstract class DubboBaseMetricsInterceptor implements Interceptor {
 
     @Override
     public void init(IPluginConfig config, String className, String methodName, String methodDescriptor) {
-        Tags tags = new Tags("application", ConfigConst.Namespace.DUBBO, "service");
+        Tags tags = new Tags(DubboMetricTags.CATEGORY.name, DubboMetricTags.TYPE.name, DubboMetricTags.LABEL_NAME.name);
         DUBBO_METRICS = ServiceMetricRegistry.getOrCreate(config, tags, DubboMetrics.DUBBO_METRICS_SUPPLIER);
     }
+
 }

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/alibaba/AlibabaDubboAsyncMetricsInterceptor.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/alibaba/AlibabaDubboAsyncMetricsInterceptor.java
@@ -16,7 +16,7 @@ public class AlibabaDubboAsyncMetricsInterceptor extends DubboBaseMetricsInterce
     public void before(MethodInfo methodInfo, Context context) {
         ResponseCallback responseCallback = (ResponseCallback) methodInfo.getArgs()[0];
         AsyncContext asyncContext = context.exportAsync();
-        AlibabaDubboMetricsCallback alibabaDubboMetricsCallback = new AlibabaDubboMetricsCallback(responseCallback, asyncContext, DUBBO_METRICS);
+        AlibabaDubboMetricsCallback alibabaDubboMetricsCallback = new AlibabaDubboMetricsCallback(responseCallback, asyncContext);
         methodInfo.changeArg(0, alibabaDubboMetricsCallback);
     }
 }

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/alibaba/AlibabaDubboMetricsCallback.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/alibaba/AlibabaDubboMetricsCallback.java
@@ -7,18 +7,16 @@ import com.megaease.easeagent.plugin.api.context.AsyncContext;
 import com.megaease.easeagent.plugin.api.context.ContextUtils;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
 import com.megaease.easeagent.plugin.dubbo.AlibabaDubboCtxUtils;
-import com.megaease.easeagent.plugin.dubbo.interceptor.metrics.DubboMetrics;
+
+import static com.megaease.easeagent.plugin.dubbo.interceptor.metrics.DubboBaseMetricsInterceptor.DUBBO_METRICS;
 
 public class AlibabaDubboMetricsCallback implements ResponseCallback {
     private ResponseCallback responseCallback;
     private AsyncContext asyncContext;
 
-    private DubboMetrics dubboMetrics;
-
-    public AlibabaDubboMetricsCallback(ResponseCallback responseCallback, AsyncContext asyncContext, DubboMetrics dubboMetrics) {
+    public AlibabaDubboMetricsCallback(ResponseCallback responseCallback, AsyncContext asyncContext) {
         this.responseCallback = responseCallback;
         this.asyncContext = asyncContext;
-        this.dubboMetrics = dubboMetrics;
     }
 
     @Override
@@ -43,9 +41,9 @@ public class AlibabaDubboMetricsCallback implements ResponseCallback {
         try(Cleaner cleaner = asyncContext.importToCurrent()) {
             Context context = EaseAgent.getContext();
             boolean callResult = AlibabaDubboCtxUtils.checkCallResult(response, throwable);
-            Long duration = ContextUtils.getDuration(context);
+            Long duration = ContextUtils.getDuration(context, AlibabaDubboCtxUtils.BEGIN_TIME);
             String service = context.get(AlibabaDubboCtxUtils.METRICS_SERVICE_NAME);
-            dubboMetrics.collect(service, duration, callResult);
+            DUBBO_METRICS.collect(service, duration, callResult);
         }
     }
 }

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/alibaba/AlibabaDubboMetricsInterceptor.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/alibaba/AlibabaDubboMetricsInterceptor.java
@@ -15,6 +15,7 @@ import com.megaease.easeagent.plugin.dubbo.DubboPlugin;
 import com.megaease.easeagent.plugin.dubbo.advice.AlibabaDubboAdvice;
 import com.megaease.easeagent.plugin.dubbo.interceptor.metrics.DubboBaseMetricsInterceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
+import com.megaease.easeagent.plugin.utils.SystemClock;
 
 import java.util.concurrent.Future;
 
@@ -24,7 +25,7 @@ public class AlibabaDubboMetricsInterceptor extends DubboBaseMetricsInterceptor 
 
 	@Override
 	public void before(MethodInfo methodInfo, Context context) {
-		ContextUtils.setBeginTime(context);
+		context.put(AlibabaDubboCtxUtils.BEGIN_TIME, SystemClock.now());
         Invoker<?> invoker = (Invoker<?>) methodInfo.getArgs()[0];
         Invocation invocation = (Invocation) methodInfo.getArgs()[1];
         boolean isAsync = RpcUtils.isAsync(invoker.getUrl(), invocation);
@@ -46,7 +47,7 @@ public class AlibabaDubboMetricsInterceptor extends DubboBaseMetricsInterceptor 
             return;
 		}
 
-        Long duration = ContextUtils.getDuration(context);
+		Long duration = ContextUtils.getDuration(context, AlibabaDubboCtxUtils.BEGIN_TIME);
 		Result retValue = (Result) methodInfo.getRetValue();
 		String interfaceSignature = AlibabaDubboCtxUtils.interfaceSignature(invocation);
         boolean callResult = AlibabaDubboCtxUtils.checkCallResult(retValue, methodInfo.getThrowable());

--- a/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/apache/ApacheDubboMetricsAsyncCallback.java
+++ b/plugins/dubbo/src/main/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/apache/ApacheDubboMetricsAsyncCallback.java
@@ -6,30 +6,28 @@ import com.megaease.easeagent.plugin.api.context.AsyncContext;
 import com.megaease.easeagent.plugin.api.context.ContextUtils;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
 import com.megaease.easeagent.plugin.dubbo.ApacheDubboCtxUtils;
-import com.megaease.easeagent.plugin.dubbo.interceptor.metrics.DubboMetrics;
 import org.apache.dubbo.rpc.Result;
 
 import java.util.function.BiConsumer;
 
+import static com.megaease.easeagent.plugin.dubbo.interceptor.metrics.DubboBaseMetricsInterceptor.DUBBO_METRICS;
+
 public class ApacheDubboMetricsAsyncCallback implements BiConsumer<Result,Throwable> {
 
-    private AsyncContext asyncContext;
+    private final AsyncContext asyncContext;
 
-    private DubboMetrics dubboMetrics;
-
-    public ApacheDubboMetricsAsyncCallback(AsyncContext asyncContext, DubboMetrics dubboMetrics) {
+    public ApacheDubboMetricsAsyncCallback(AsyncContext asyncContext) {
         this.asyncContext = asyncContext;
-        this.dubboMetrics = dubboMetrics;
     }
 
     @Override
     public void accept(Result result, Throwable throwable) {
         try(Cleaner cleaner = asyncContext.importToCurrent()) {
             Context context = EaseAgent.getContext();
-            Long duration = ContextUtils.getDuration(context);
+            Long duration = ContextUtils.getDuration(context,ApacheDubboCtxUtils.BEGIN_TIME);
             boolean callResult = ApacheDubboCtxUtils.checkCallResult(result, throwable);
             String service = context.get(ApacheDubboCtxUtils.METRICS_SERVICE_NAME);
-            dubboMetrics.collect(service, duration, callResult);
+            DUBBO_METRICS.collect(service, duration, callResult);
         }
     }
 }

--- a/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/ApacheDubboBaseTest.java
+++ b/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/ApacheDubboBaseTest.java
@@ -2,14 +2,19 @@ package com.megaease.easeagent.plugin.dubbo.interceptor;
 
 import com.megaease.easeagent.mock.config.MockConfig;
 import com.megaease.easeagent.mock.plugin.api.MockEaseAgent;
+import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
+import com.megaease.easeagent.mock.plugin.api.utils.TagVerifier;
+import com.megaease.easeagent.mock.report.impl.LastJsonReporter;
 import com.megaease.easeagent.plugin.api.config.ConfigConst;
+import com.megaease.easeagent.plugin.api.metric.name.MetricField;
+import com.megaease.easeagent.plugin.api.metric.name.Tags;
 import com.megaease.easeagent.plugin.api.trace.Span;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
-import com.megaease.easeagent.plugin.dubbo.ApacheDubboCtxUtils;
-import com.megaease.easeagent.plugin.dubbo.DubboTags;
+import com.megaease.easeagent.plugin.dubbo.*;
 import com.megaease.easeagent.plugin.dubbo.config.DubboTraceConfig;
 import com.megaease.easeagent.plugin.dubbo.interceptor.trace.apache.ApacheDubboTraceInterceptor;
 import com.megaease.easeagent.plugin.field.AgentFieldReflectAccessor;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.report.tracing.ReportSpan;
 import com.megaease.easeagent.plugin.utils.common.JsonUtil;
 import org.apache.dubbo.common.URL;
@@ -47,9 +52,10 @@ public abstract class ApacheDubboBaseTest {
 
     protected AsyncRpcResult asyncRpcResult = new AsyncRpcResult((Invocation) null);
 
+	protected abstract Interceptor createInterceptor();
 
 	@Before
-	public void setup() {
+	public void init() {
 		MockitoAnnotations.openMocks(this);
 
 		URL consumerURL = URL.valueOf("dubbo://127.0.0.1:0/com.magaease.easeagent.service.DubboService?side=consumer&application=dubbo-consumer&group=consumer&version=1.0.0");
@@ -63,7 +69,33 @@ public abstract class ApacheDubboBaseTest {
 		providerInvocation = new RpcInvocation("sayHello", new Class[]{String.class}, new Object[]{"hello"}, providerAttachment, providerInvoker);
 
 		EaseAgent.configFactory = MockConfig.getPluginConfigManager();
+		DubboPlugin dubboPlugin = new DubboPlugin();
+		InterceptorTestUtils.init(createInterceptor(), dubboPlugin);
 	}
+
+	protected void assertSuccessMetrics() {
+		assertMetrics(true);
+	}
+
+	protected void assertFailureMetrics() {
+		assertMetrics(false);
+	}
+
+	private void assertMetrics(boolean success) {
+		TagVerifier tagVerifier = new TagVerifier()
+				.add(Tags.CATEGORY, DubboMetricTags.CATEGORY.name)
+				.add(Tags.TYPE, DubboMetricTags.TYPE.name)
+				.add(DubboMetricTags.LABEL_NAME.name, ApacheDubboCtxUtils.interfaceSignature(consumerInvocation));
+		LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
+		Map<String, Object> metric = lastJsonReporter.flushAndOnlyOne();
+		assertEquals(1, metric.get(MetricField.EXECUTION_COUNT.getField()));
+		if (success) {
+			assertEquals(0, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+		} else {
+			assertEquals(1, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+		}
+	}
+
 
 	protected void assertConsumerTrace(Object retValue, String errorMessage) {
 		assertTrace(consumerInvocation, retValue, errorMessage);
@@ -82,18 +114,18 @@ public abstract class ApacheDubboBaseTest {
 		assertNotNull(mockSpan);
 		if (isConsumer) {
 			assertEquals(Span.Kind.CLIENT.name(), mockSpan.kind());
-			assertEquals(url.getParameter(CommonConstants.APPLICATION_KEY), mockSpan.tag(DubboTags.CLIENT_APPLICATION.name));
-			assertEquals(url.getParameter(CommonConstants.GROUP_KEY), mockSpan.tag(DubboTags.GROUP.name));
-			assertEquals(url.getParameter(CommonConstants.VERSION_KEY), mockSpan.tag(DubboTags.SERVICE_VERSION.name));
-			assertEquals(ApacheDubboCtxUtils.method(invocation), mockSpan.tag(DubboTags.METHOD.name));
-			assertEquals(url.getPath(), mockSpan.tag(DubboTags.SERVICE.name));
+			assertEquals(url.getParameter(CommonConstants.APPLICATION_KEY), mockSpan.tag(DubboTraceTags.CLIENT_APPLICATION.name));
+			assertEquals(url.getParameter(CommonConstants.GROUP_KEY), mockSpan.tag(DubboTraceTags.GROUP.name));
+			assertEquals(url.getParameter(CommonConstants.VERSION_KEY), mockSpan.tag(DubboTraceTags.SERVICE_VERSION.name));
+			assertEquals(ApacheDubboCtxUtils.method(invocation), mockSpan.tag(DubboTraceTags.METHOD.name));
+			assertEquals(url.getPath(), mockSpan.tag(DubboTraceTags.SERVICE.name));
 			String expectedArgs = dubboTraceConfig.argsCollectEnabled() ? JsonUtil.toJson(invocation.getArguments()) : null;
 			String expectedResult = dubboTraceConfig.resultCollectEnabled() && retValue != null ? JsonUtil.toJson(retValue) : null;
-			assertEquals(expectedArgs, mockSpan.tag(DubboTags.ARGS.name));
-			assertEquals(expectedResult, mockSpan.tag(DubboTags.RESULT.name));
+			assertEquals(expectedArgs, mockSpan.tag(DubboTraceTags.ARGS.name));
+			assertEquals(expectedResult, mockSpan.tag(DubboTraceTags.RESULT.name));
 		} else {
 			assertEquals(Span.Kind.SERVER.name(), mockSpan.kind());
-			assertEquals(url.getParameter(CommonConstants.APPLICATION_KEY), mockSpan.tag(DubboTags.SERVER_APPLICATION.name));
+			assertEquals(url.getParameter(CommonConstants.APPLICATION_KEY), mockSpan.tag(DubboTraceTags.SERVER_APPLICATION.name));
 		}
 		assertEquals(ApacheDubboCtxUtils.name(invocation).toLowerCase(), mockSpan.name());
 		assertEquals(ConfigConst.Namespace.DUBBO, mockSpan.remoteServiceName());

--- a/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/apache/ApacheDubboMetricsInterceptorTest.java
+++ b/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/metrics/apache/ApacheDubboMetricsInterceptorTest.java
@@ -1,26 +1,16 @@
 package com.megaease.easeagent.plugin.dubbo.interceptor.metrics.apache;
 
-import com.megaease.easeagent.mock.plugin.api.MockEaseAgent;
 import com.megaease.easeagent.mock.plugin.api.junit.EaseAgentJunit4ClassRunner;
-import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
-import com.megaease.easeagent.mock.plugin.api.utils.TagVerifier;
-import com.megaease.easeagent.mock.report.impl.LastJsonReporter;
 import com.megaease.easeagent.plugin.api.Context;
 import com.megaease.easeagent.plugin.api.context.ContextUtils;
-import com.megaease.easeagent.plugin.api.metric.name.MetricField;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
-import com.megaease.easeagent.plugin.dubbo.ApacheDubboCtxUtils;
-import com.megaease.easeagent.plugin.dubbo.DubboPlugin;
 import com.megaease.easeagent.plugin.dubbo.interceptor.ApacheDubboBaseTest;
 import com.megaease.easeagent.plugin.enums.Order;
 import com.megaease.easeagent.plugin.field.AgentFieldReflectAccessor;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -28,13 +18,11 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(EaseAgentJunit4ClassRunner.class)
 public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
 
-	private ApacheDubboMetricsInterceptor apacheDubboMetricsInterceptor;
+	private static final ApacheDubboMetricsInterceptor apacheDubboMetricsInterceptor = new ApacheDubboMetricsInterceptor();
 
-	@Before
-	public void setup() {
-		super.setup();
-		apacheDubboMetricsInterceptor = new ApacheDubboMetricsInterceptor();
-		initDubboMetrics();
+	@Override
+	protected Interceptor createInterceptor() {
+		return apacheDubboMetricsInterceptor;
 	}
 
 	@Test
@@ -48,19 +36,6 @@ public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
 	}
 
 	@Test
-	public void init() {
-		assertNotNull(AgentFieldReflectAccessor.getStaticFieldValue(ApacheDubboMetricsInterceptor.class, "DUBBO_METRICS"));
-	}
-
-	@Test
-	public void before() {
-		Context context = EaseAgent.getContext();
-		apacheDubboMetricsInterceptor.before(null, context);
-		assertNotNull(ContextUtils.getBeginTime(context));
-	}
-
-
-	@Test
 	public void rpcConsumerCallSuccess() {
 		MethodInfo methodInfo = MethodInfo.builder()
 				.invoker(consumerInvoker)
@@ -70,14 +45,10 @@ public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
 				.build();
 
 		Context context = EaseAgent.getContext();
-		LastJsonReporter lastJsonReporter = getLastJsonReporter();
-
 		apacheDubboMetricsInterceptor.before(methodInfo, context);
 		apacheDubboMetricsInterceptor.after(methodInfo, context);
-		Map<String, Object> metric = lastJsonReporter.flushAndOnlyOne();
-		assertEquals(1, metric.get(MetricField.EXECUTION_COUNT.getField()));
-		assertEquals(0, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
-		lastJsonReporter.clean();
+
+		assertSuccessMetrics();
 	}
 
 	@Test
@@ -90,14 +61,10 @@ public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
 				.build();
 
 		Context context = EaseAgent.getContext();
-		LastJsonReporter lastJsonReporter = getLastJsonReporter();
-
 		apacheDubboMetricsInterceptor.before(methodInfo, context);
 		apacheDubboMetricsInterceptor.after(methodInfo, context);
-		Map<String, Object> metric = lastJsonReporter.flushAndOnlyOne();
-		assertEquals(1, metric.get(MetricField.EXECUTION_COUNT.getField()));
-		assertEquals(1, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
-		lastJsonReporter.clean();
+
+		assertFailureMetrics();
 	}
 
 	@Test
@@ -110,14 +77,10 @@ public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
 				.build();
 
 		Context context = EaseAgent.getContext();
-		LastJsonReporter lastJsonReporter = getLastJsonReporter();
-
 		apacheDubboMetricsInterceptor.before(methodInfo, context);
 		apacheDubboMetricsInterceptor.after(methodInfo, context);
-		Map<String, Object> metric = lastJsonReporter.flushAndOnlyOne();
-		assertEquals(1, metric.get(MetricField.EXECUTION_COUNT.getField()));
-		assertEquals(1, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
-		lastJsonReporter.clean();
+
+		assertFailureMetrics();
 	}
 
 
@@ -143,11 +106,7 @@ public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
         thread.start();
         thread.join();
 
-        LastJsonReporter lastJsonReporter = getLastJsonReporter();
-		Map<String, Object> metric = lastJsonReporter.flushAndOnlyOne();
-		assertEquals(1, metric.get(MetricField.EXECUTION_COUNT.getField()));
-		assertEquals(0, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
-		lastJsonReporter.clean();
+        assertSuccessMetrics();
 	}
 
 	@Test
@@ -172,26 +131,6 @@ public class ApacheDubboMetricsInterceptorTest extends ApacheDubboBaseTest {
         thread.start();
         thread.join();
 
-		LastJsonReporter lastJsonReporter = getLastJsonReporter();
-		Map<String, Object> metric = lastJsonReporter.flushAndOnlyOne();
-		assertEquals(1, metric.get(MetricField.EXECUTION_COUNT.getField()));
-		assertEquals(1, metric.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
-		lastJsonReporter.clean();
+		assertFailureMetrics();
 	}
-
-	private void initDubboMetrics() {
-		DubboPlugin dubboPlugin = new DubboPlugin();
-		InterceptorTestUtils.init(apacheDubboMetricsInterceptor, dubboPlugin);
-	}
-
-	@NotNull
-	private LastJsonReporter getLastJsonReporter() {
-		TagVerifier tagVerifier = new TagVerifier()
-				.add("category", "application")
-				.add("type", "dubbo")
-				.add("service", ApacheDubboCtxUtils.interfaceSignature(consumerInvocation));
-		LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
-		return lastJsonReporter;
-	}
-
 }

--- a/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/trace/alibaba/AlibabaDubboAsyncTraceInterceptorTest.java
+++ b/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/trace/alibaba/AlibabaDubboAsyncTraceInterceptorTest.java
@@ -8,6 +8,7 @@ import com.megaease.easeagent.plugin.bridge.EaseAgent;
 import com.megaease.easeagent.plugin.dubbo.DubboPlugin;
 import com.megaease.easeagent.plugin.dubbo.interceptor.AlibabaDubboBaseTest;
 import com.megaease.easeagent.plugin.enums.Order;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,21 +21,17 @@ import static org.junit.Assert.*;
 @RunWith(EaseAgentJunit4ClassRunner.class)
 public class AlibabaDubboAsyncTraceInterceptorTest extends AlibabaDubboBaseTest {
 
-    private AlibabaDubboAsyncTraceInterceptor alibabaDubboAsyncTraceInterceptor;
-    private AlibabaDubboTraceInterceptor alibabaDubboTraceInterceptor;
+    private static final AlibabaDubboAsyncTraceInterceptor alibabaDubboAsyncTraceInterceptor = new AlibabaDubboAsyncTraceInterceptor();
+    private static final AlibabaDubboTraceInterceptor alibabaDubboTraceInterceptor = new AlibabaDubboTraceInterceptor();
 
 
-	@Before
-	public void setup() {
-		super.setup();
-		DubboPlugin dubboPlugin = new DubboPlugin();
-		this.alibabaDubboAsyncTraceInterceptor = new AlibabaDubboAsyncTraceInterceptor();
-		this.alibabaDubboTraceInterceptor = new AlibabaDubboTraceInterceptor();
-		InterceptorTestUtils.init(alibabaDubboAsyncTraceInterceptor, dubboPlugin);
+	@Override
+	protected Interceptor createInterceptor() {
+		return alibabaDubboAsyncTraceInterceptor;
 	}
 
 	@Test
-	public void init() {
+	public void testExternalConfig() {
         assertNotNull(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG);
         assertTrue(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG.resultCollectEnabled());
         assertTrue(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG.argsCollectEnabled());

--- a/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/trace/alibaba/AlibabaDubboTraceInterceptorTest.java
+++ b/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/trace/alibaba/AlibabaDubboTraceInterceptorTest.java
@@ -1,15 +1,13 @@
 package com.megaease.easeagent.plugin.dubbo.interceptor.trace.alibaba;
 
 import com.megaease.easeagent.mock.plugin.api.junit.EaseAgentJunit4ClassRunner;
-import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
 import com.megaease.easeagent.plugin.api.Context;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
-import com.megaease.easeagent.plugin.dubbo.DubboPlugin;
 import com.megaease.easeagent.plugin.dubbo.interceptor.AlibabaDubboBaseTest;
 import com.megaease.easeagent.plugin.enums.Order;
 import com.megaease.easeagent.plugin.field.AgentFieldReflectAccessor;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,18 +16,15 @@ import static org.junit.Assert.*;
 @RunWith(EaseAgentJunit4ClassRunner.class)
 public class AlibabaDubboTraceInterceptorTest extends AlibabaDubboBaseTest {
 
-	private AlibabaDubboTraceInterceptor alibabaDubboTraceInterceptor;
+	private static final AlibabaDubboTraceInterceptor alibabaDubboTraceInterceptor = new AlibabaDubboTraceInterceptor();
 
-	@Before
-	public void setup() {
-		super.setup();
-		DubboPlugin dubboPlugin = new DubboPlugin();
-		this.alibabaDubboTraceInterceptor = new AlibabaDubboTraceInterceptor();
-		InterceptorTestUtils.init(alibabaDubboTraceInterceptor, dubboPlugin);
+	@Override
+	protected Interceptor createInterceptor() {
+		return alibabaDubboTraceInterceptor;
 	}
 
 	@Test
-	public void init() {
+	public void testExternalConfig() {
         assertNotNull(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG);
         assertTrue(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG.resultCollectEnabled());
         assertTrue(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG.argsCollectEnabled());

--- a/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/trace/apache/ApacheDubboTraceInterceptorTest.java
+++ b/plugins/dubbo/src/test/java/com/megaease/easeagent/plugin/dubbo/interceptor/trace/apache/ApacheDubboTraceInterceptorTest.java
@@ -1,16 +1,14 @@
 package com.megaease.easeagent.plugin.dubbo.interceptor.trace.apache;
 
 import com.megaease.easeagent.mock.plugin.api.junit.EaseAgentJunit4ClassRunner;
-import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
 import com.megaease.easeagent.plugin.api.Context;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
-import com.megaease.easeagent.plugin.dubbo.DubboPlugin;
 import com.megaease.easeagent.plugin.dubbo.interceptor.ApacheDubboBaseTest;
 import com.megaease.easeagent.plugin.dubbo.interceptor.trace.alibaba.AlibabaDubboTraceInterceptor;
 import com.megaease.easeagent.plugin.enums.Order;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
 import org.apache.dubbo.rpc.Result;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -19,18 +17,15 @@ import static org.junit.Assert.*;
 @RunWith(EaseAgentJunit4ClassRunner.class)
 public class ApacheDubboTraceInterceptorTest extends ApacheDubboBaseTest {
 
-	private ApacheDubboTraceInterceptor apacheDubboTraceInterceptor;
+	private static final ApacheDubboTraceInterceptor apacheDubboTraceInterceptor = new ApacheDubboTraceInterceptor();
 
-	@Before
-	public void setup() {
-		super.setup();
-		DubboPlugin dubboPlugin = new DubboPlugin();
-		this.apacheDubboTraceInterceptor = new ApacheDubboTraceInterceptor();
-		InterceptorTestUtils.init(apacheDubboTraceInterceptor, dubboPlugin);
+	@Override
+	public Interceptor createInterceptor() {
+		return apacheDubboTraceInterceptor;
 	}
 
 	@Test
-	public void init() {
+	public void testExternalConfig() {
         assertNotNull(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG);
         assertTrue(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG.resultCollectEnabled());
         assertTrue(AlibabaDubboTraceInterceptor.DUBBO_TRACE_CONFIG.argsCollectEnabled());

--- a/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/MotanCtxUtils.java
+++ b/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/MotanCtxUtils.java
@@ -23,6 +23,7 @@ public class MotanCtxUtils {
 	public static final String CLIENT_REQUEST_CONTEXT = MotanCtxUtils.class.getName() + ".CLIENT_REQUEST_CONTEXT";
 	public static final String SERVER_REQUEST_CONTEXT = MotanCtxUtils.class.getName() + ".SERVER_REQUEST_CONTEXT";
 	public static final String METRICS_SERVICE_NAME = MotanCtxUtils.class.getName() + ".METRICS_SERVICE_NAME";
+	public static final String BEGIN_TIME = MotanCtxUtils.class.getName() + ".BEGIN_TIME";
 
 	public static String interfaceSignature(Request request) {
 		return new StringBuilder(request.getInterfaceName())

--- a/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MetricsFutureListener.java
+++ b/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MetricsFutureListener.java
@@ -9,13 +9,13 @@ import com.megaease.easeagent.plugin.motan.interceptor.MotanCtxUtils;
 import com.weibo.api.motan.rpc.Future;
 import com.weibo.api.motan.rpc.FutureListener;
 
+import static com.megaease.easeagent.plugin.motan.interceptor.metrics.MotanBaseMetricsInterceptor.MOTAN_METRIC;
+
 public class MetricsFutureListener implements FutureListener {
-	private MotanMetric motanMetric;
-	private AsyncContext asyncContext;
+	private final AsyncContext asyncContext;
 
 
-	public MetricsFutureListener(MotanMetric motanMetric, AsyncContext asyncContext) {
-		this.motanMetric = motanMetric;
+	public MetricsFutureListener(AsyncContext asyncContext) {
 		this.asyncContext = asyncContext;
 	}
 
@@ -23,10 +23,10 @@ public class MetricsFutureListener implements FutureListener {
 	public void operationComplete(Future future) throws Exception {
 		try(Cleaner cleaner = asyncContext.importToCurrent()){
 			Context context = EaseAgent.getContext();
-			Long duration = ContextUtils.getDuration(context);
+			Long duration = ContextUtils.getDuration(context,MotanCtxUtils.BEGIN_TIME);
 			String service = context.get(MotanCtxUtils.METRICS_SERVICE_NAME);
 			boolean callResult = future.getException() == null;
-			motanMetric.collectMetric(service, duration, callResult);
+            MOTAN_METRIC.collectMetric(service, duration, callResult);
 		}
 	}
 }

--- a/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanBaseMetricsInterceptor.java
+++ b/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanBaseMetricsInterceptor.java
@@ -1,16 +1,13 @@
 package com.megaease.easeagent.plugin.motan.interceptor.metrics;
 
 import com.megaease.easeagent.plugin.api.config.IPluginConfig;
-import com.megaease.easeagent.plugin.api.metric.MetricRegistry;
 import com.megaease.easeagent.plugin.api.metric.ServiceMetricRegistry;
-import com.megaease.easeagent.plugin.api.metric.ServiceMetricSupplier;
-import com.megaease.easeagent.plugin.api.metric.name.NameFactory;
 import com.megaease.easeagent.plugin.api.metric.name.Tags;
 import com.megaease.easeagent.plugin.enums.Order;
 import com.megaease.easeagent.plugin.interceptor.Interceptor;
 
 public abstract class MotanBaseMetricsInterceptor implements Interceptor {
-    protected MotanMetric motanMetric;
+    public static volatile MotanMetric MOTAN_METRIC;
 
     @Override
     public int order() {
@@ -24,18 +21,8 @@ public abstract class MotanBaseMetricsInterceptor implements Interceptor {
 
     @Override
     public void init(IPluginConfig config, String className, String methodName, String methodDescriptor) {
-        Tags tags = new Tags("application", "motan", "service");
-        motanMetric = ServiceMetricRegistry.getOrCreate(config, tags, new ServiceMetricSupplier<MotanMetric>() {
-            @Override
-            public NameFactory newNameFactory() {
-                return MotanMetric.nameFactory();
-            }
-
-            @Override
-            public MotanMetric newInstance(MetricRegistry metricRegistry, NameFactory nameFactory) {
-                return new MotanMetric(metricRegistry, nameFactory);
-            }
-        });
+        Tags tags = new Tags(MotanMetricTags.CATEGORY.name, MotanMetricTags.TYPE.name, MotanMetricTags.LABEL_NAME.name);
+        MOTAN_METRIC = ServiceMetricRegistry.getOrCreate(config, tags, MotanMetric.MOTAN_METRIC_SUPPLIER);
     }
 
 }

--- a/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanMetric.java
+++ b/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanMetric.java
@@ -17,10 +17,7 @@
 
 package com.megaease.easeagent.plugin.motan.interceptor.metrics;
 
-import com.megaease.easeagent.plugin.api.metric.Counter;
-import com.megaease.easeagent.plugin.api.metric.Meter;
-import com.megaease.easeagent.plugin.api.metric.MetricRegistry;
-import com.megaease.easeagent.plugin.api.metric.ServiceMetric;
+import com.megaease.easeagent.plugin.api.metric.*;
 import com.megaease.easeagent.plugin.api.metric.name.*;
 import com.megaease.easeagent.plugin.tools.metrics.LastMinutesCounterGauge;
 import com.megaease.easeagent.plugin.utils.ImmutableMap;
@@ -30,9 +27,22 @@ import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 public class MotanMetric extends ServiceMetric {
+
     public MotanMetric(@Nonnull MetricRegistry metricRegistry, @Nonnull NameFactory nameFactory) {
         super(metricRegistry, nameFactory);
     }
+
+    public static final ServiceMetricSupplier<MotanMetric> MOTAN_METRIC_SUPPLIER = new ServiceMetricSupplier<MotanMetric>() {
+        @Override
+        public NameFactory newNameFactory() {
+            return MotanMetric.nameFactory();
+        }
+
+        @Override
+        public MotanMetric newInstance(MetricRegistry metricRegistry, NameFactory nameFactory) {
+            return new MotanMetric(metricRegistry, nameFactory);
+        }
+    };
 
     public static NameFactory nameFactory() {
         return NameFactory.createBuilder()

--- a/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanMetricTags.java
+++ b/plugins/motan/src/main/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanMetricTags.java
@@ -1,0 +1,14 @@
+package com.megaease.easeagent.plugin.motan.interceptor.metrics;
+
+public enum MotanMetricTags {
+	CATEGORY("application"),
+	TYPE("motan"),
+	LABEL_NAME("interface"),
+	;
+
+	public final String name;
+
+	MotanMetricTags(String name) {
+		this.name = name;
+	}
+}

--- a/plugins/motan/src/test/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanMetricsInterceptorTest.java
+++ b/plugins/motan/src/test/java/com/megaease/easeagent/plugin/motan/interceptor/metrics/MotanMetricsInterceptorTest.java
@@ -1,87 +1,46 @@
 package com.megaease.easeagent.plugin.motan.interceptor.metrics;
 
-import com.megaease.easeagent.mock.plugin.api.MockEaseAgent;
 import com.megaease.easeagent.mock.plugin.api.junit.EaseAgentJunit4ClassRunner;
-import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
-import com.megaease.easeagent.mock.plugin.api.utils.TagVerifier;
-import com.megaease.easeagent.mock.report.impl.LastJsonReporter;
 import com.megaease.easeagent.plugin.api.Context;
 import com.megaease.easeagent.plugin.api.config.ConfigConst;
 import com.megaease.easeagent.plugin.api.context.ContextUtils;
-import com.megaease.easeagent.plugin.api.metric.name.MetricField;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
 import com.megaease.easeagent.plugin.enums.Order;
-import com.megaease.easeagent.plugin.field.AgentFieldReflectAccessor;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
-import com.megaease.easeagent.plugin.motan.MotanPlugin;
 import com.megaease.easeagent.plugin.motan.interceptor.MotanCtxUtils;
-import com.weibo.api.motan.protocol.rpc.DefaultRpcReferer;
-import com.weibo.api.motan.rpc.*;
-import org.junit.Before;
+import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanInterceptorTest;
+import com.weibo.api.motan.rpc.DefaultResponseFuture;
+import com.weibo.api.motan.rpc.ResponseFuture;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
 
 @RunWith(EaseAgentJunit4ClassRunner.class)
-public class MotanMetricsInterceptorTest {
+public class MotanMetricsInterceptorTest extends MotanInterceptorTest {
 
-    @Mock
-    DefaultRpcReferer<?> defaultRpcReferer;
-
-    @Mock
-    DefaultRequest request;
-
-    DefaultResponse successResponse;
-
-    DefaultResponse failureResponse;
-
+    private static final MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
 
     @Test
     public void getType() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
         assertEquals(ConfigConst.PluginID.METRIC, motanMetricsInterceptor.getType());
     }
+
     @Test
     public void order() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
         assertEquals(Order.METRIC.getOrder(), motanMetricsInterceptor.order());
     }
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.openMocks(this);
-        URL clientUrl = URL.valueOf("motan://127.0.0.1:1234/com.megaease.easeagent.motan.TestService.test(String,Integer)");
-        when(defaultRpcReferer.getUrl()).thenReturn(clientUrl);
-        when(request.getInterfaceName()).thenReturn("com.megaease.easeagent.motan.TestService");
-        when(request.getMethodName()).thenReturn("test");
-        when(request.getParamtersDesc()).thenReturn("String,Integer");
-        when(request.getArguments()).thenReturn(new Object[]{"motan test", 1234});
-
-        RuntimeException motanException = new RuntimeException("motan exception");
-        successResponse = new DefaultResponse("success");
-        failureResponse = new DefaultResponse();
-        failureResponse.setException(motanException);
+    @Override
+    protected Interceptor createInterceptor() {
+        return motanMetricsInterceptor;
     }
 
-    @Test
-    public void init() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-        assertNotNull(AgentFieldReflectAccessor.getFieldValue(motanMetricsInterceptor, "motanMetric"));
-    }
 
     @Test
     public void before() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-
         Context context = EaseAgent.getContext();
         MethodInfo methodInfo = MethodInfo.builder()
             .invoker(defaultRpcReferer)
@@ -89,87 +48,60 @@ public class MotanMetricsInterceptorTest {
             .retValue(failureResponse)
             .build();
         motanMetricsInterceptor.before(methodInfo, context);
-        assertNotNull(ContextUtils.getBeginTime(context));
+        assertNotNull(ContextUtils.getFromContext(context, MotanCtxUtils.BEGIN_TIME));
     }
 
     @Test
     public void rpcCallFailure() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-        Context context = EaseAgent.getContext();
 
         MethodInfo methodInfo = MethodInfo.builder()
                 .invoker(defaultRpcReferer)
                 .args(new Object[]{request})
                 .retValue(failureResponse)
                 .build();
+
+        Context context = EaseAgent.getContext();
         motanMetricsInterceptor.before(methodInfo, context);
         motanMetricsInterceptor.after(methodInfo, context);
 
-        TagVerifier tagVerifier = new TagVerifier()
-                .add("category", "application")
-                .add("type", "motan")
-                .add("service", MotanCtxUtils.interfaceSignature(request));
-        LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
-        Map<String, Object> metrics = lastJsonReporter.flushAndOnlyOne();
-        assertEquals(1, metrics.get(MetricField.EXECUTION_COUNT.getField()));
-        assertEquals(1, metrics.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+        assertFailureMetrics();
     }
 
     @Test
     public void rpcCallException() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-        Context context = EaseAgent.getContext();
 
         MethodInfo methodInfo = MethodInfo.builder()
                 .invoker(defaultRpcReferer)
                 .args(new Object[]{request})
                 .throwable(failureResponse.getException())
                 .build();
+
+        Context context = EaseAgent.getContext();
         motanMetricsInterceptor.before(methodInfo, context);
         motanMetricsInterceptor.after(methodInfo, context);
 
-        TagVerifier tagVerifier = new TagVerifier()
-                .add("category", "application")
-                .add("type", "motan")
-                .add("service", MotanCtxUtils.interfaceSignature(request));
-        LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
-        Map<String, Object> metrics = lastJsonReporter.flushAndOnlyOne();
-        assertEquals(1, metrics.get(MetricField.EXECUTION_COUNT.getField()));
-        assertEquals(1, metrics.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+        assertFailureMetrics();
     }
 
     @Test
     public void rpcCallSuccess() {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-        Context context = EaseAgent.getContext();
 
         MethodInfo methodInfo = MethodInfo.builder()
                 .invoker(defaultRpcReferer)
                 .args(new Object[]{request})
                 .retValue(successResponse)
                 .build();
+
+        Context context = EaseAgent.getContext();
         motanMetricsInterceptor.before(methodInfo, context);
         motanMetricsInterceptor.after(methodInfo, context);
 
-        TagVerifier tagVerifier = new TagVerifier()
-                .add("category", "application")
-                .add("type", "motan")
-                .add("service", MotanCtxUtils.interfaceSignature(request));
-        LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
-        Map<String, Object> metrics = lastJsonReporter.flushAndOnlyOne();
-        assertEquals(1, metrics.get(MetricField.EXECUTION_COUNT.getField()));
-        assertEquals(0, metrics.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+        assertSuccessMetrics();
     }
 
 
     @Test
     public void rpcAsyncCallFailure() throws InterruptedException {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-        Context context = EaseAgent.getContext();
         DefaultResponseFuture defaultResponseFuture = new DefaultResponseFuture(null, 0, null);
 
         MethodInfo methodInfo = MethodInfo.builder()
@@ -177,6 +109,8 @@ public class MotanMetricsInterceptorTest {
                 .args(new Object[]{request})
                 .retValue(defaultResponseFuture)
                 .build();
+
+        Context context = EaseAgent.getContext();
         motanMetricsInterceptor.before(methodInfo, context);
         motanMetricsInterceptor.after(methodInfo, context);
         ResponseFuture retValue = (ResponseFuture) methodInfo.getRetValue();
@@ -186,21 +120,11 @@ public class MotanMetricsInterceptorTest {
         thread.start();
         thread.join();
 
-        TagVerifier tagVerifier = new TagVerifier()
-                .add("category", "application")
-                .add("type", "motan")
-                .add("service", MotanCtxUtils.interfaceSignature(request));
-        LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
-        Map<String, Object> metrics = lastJsonReporter.flushAndOnlyOne();
-        assertEquals(1, metrics.get(MetricField.EXECUTION_COUNT.getField()));
-        assertEquals(1, metrics.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+        assertFailureMetrics();
     }
 
     @Test
     public void rpcAsyncCallSuccess() throws InterruptedException {
-        MotanMetricsInterceptor motanMetricsInterceptor = new MotanMetricsInterceptor();
-        InterceptorTestUtils.init(motanMetricsInterceptor, new MotanPlugin());
-        Context context = EaseAgent.getContext();
         DefaultResponseFuture defaultResponseFuture = new DefaultResponseFuture(null, 0, null);
 
         MethodInfo methodInfo = MethodInfo.builder()
@@ -208,6 +132,8 @@ public class MotanMetricsInterceptorTest {
                 .args(new Object[]{request})
                 .retValue(defaultResponseFuture)
                 .build();
+
+        Context context = EaseAgent.getContext();
         motanMetricsInterceptor.before(methodInfo, context);
         motanMetricsInterceptor.after(methodInfo, context);
         ResponseFuture retValue = (ResponseFuture) methodInfo.getRetValue();
@@ -217,13 +143,6 @@ public class MotanMetricsInterceptorTest {
         thread.start();
         thread.join();
 
-        TagVerifier tagVerifier = new TagVerifier()
-                .add("category", "application")
-                .add("type", "motan")
-                .add("service", MotanCtxUtils.interfaceSignature(request));
-        LastJsonReporter lastJsonReporter = MockEaseAgent.lastMetricJsonReporter(tagVerifier::verifyAnd);
-        Map<String, Object> metrics = lastJsonReporter.flushAndOnlyOne();
-        assertEquals(1, metrics.get(MetricField.EXECUTION_COUNT.getField()));
-        assertEquals(0, metrics.get(MetricField.EXECUTION_ERROR_COUNT.getField()));
+        assertSuccessMetrics();
     }
 }

--- a/plugins/motan/src/test/java/com/megaease/easeagent/plugin/motan/interceptor/trace/consumer/MotanConsumerInterceptorTest.java
+++ b/plugins/motan/src/test/java/com/megaease/easeagent/plugin/motan/interceptor/trace/consumer/MotanConsumerInterceptorTest.java
@@ -1,36 +1,31 @@
 package com.megaease.easeagent.plugin.motan.interceptor.trace.consumer;
 
 import com.megaease.easeagent.mock.plugin.api.junit.EaseAgentJunit4ClassRunner;
-import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
 import com.megaease.easeagent.plugin.api.Context;
 import com.megaease.easeagent.plugin.api.config.ConfigConst;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
 import com.megaease.easeagent.plugin.enums.Order;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
-import com.megaease.easeagent.plugin.motan.MotanPlugin;
 import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanBaseInterceptor;
-import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanTraceInterceptorTest;
+import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanInterceptorTest;
 import com.weibo.api.motan.rpc.DefaultResponse;
 import com.weibo.api.motan.rpc.DefaultResponseFuture;
 import com.weibo.api.motan.rpc.ResponseFuture;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.*;
 
 @RunWith(EaseAgentJunit4ClassRunner.class)
-public class MotanConsumerTraceInterceptorTest extends MotanTraceInterceptorTest {
+public class MotanConsumerInterceptorTest extends MotanInterceptorTest {
 
-    private MotanConsumerTraceInterceptor motanConsumerTraceInterceptor;
+    private static final MotanConsumerTraceInterceptor motanConsumerTraceInterceptor = new MotanConsumerTraceInterceptor();
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        motanConsumerTraceInterceptor = new MotanConsumerTraceInterceptor();
-        InterceptorTestUtils.init(motanConsumerTraceInterceptor, new MotanPlugin());
+    @Override
+    protected Interceptor createInterceptor() {
+        return motanConsumerTraceInterceptor;
     }
-
 
     @Test
     public void order() {
@@ -43,7 +38,7 @@ public class MotanConsumerTraceInterceptorTest extends MotanTraceInterceptorTest
     }
 
     @Test
-    public void init() {
+    public void testExternalConfig() {
         assertNotNull(MotanBaseInterceptor.MOTAN_PLUGIN_CONFIG);
         assertTrue(MotanBaseInterceptor.MOTAN_PLUGIN_CONFIG.argsCollectEnabled());
         assertTrue(MotanBaseInterceptor.MOTAN_PLUGIN_CONFIG.resultCollectEnabled());

--- a/plugins/motan/src/test/java/com/megaease/easeagent/plugin/motan/interceptor/trace/provider/MotanProviderInterceptorTest.java
+++ b/plugins/motan/src/test/java/com/megaease/easeagent/plugin/motan/interceptor/trace/provider/MotanProviderInterceptorTest.java
@@ -2,7 +2,6 @@ package com.megaease.easeagent.plugin.motan.interceptor.trace.provider;
 
 import com.megaease.easeagent.mock.plugin.api.MockEaseAgent;
 import com.megaease.easeagent.mock.plugin.api.junit.EaseAgentJunit4ClassRunner;
-import com.megaease.easeagent.mock.plugin.api.utils.InterceptorTestUtils;
 import com.megaease.easeagent.mock.plugin.api.utils.SpanTestUtils;
 import com.megaease.easeagent.plugin.api.Context;
 import com.megaease.easeagent.plugin.api.config.ConfigConst;
@@ -10,31 +9,26 @@ import com.megaease.easeagent.plugin.api.context.RequestContext;
 import com.megaease.easeagent.plugin.api.trace.Span;
 import com.megaease.easeagent.plugin.bridge.EaseAgent;
 import com.megaease.easeagent.plugin.enums.Order;
+import com.megaease.easeagent.plugin.interceptor.Interceptor;
 import com.megaease.easeagent.plugin.interceptor.MethodInfo;
-import com.megaease.easeagent.plugin.motan.MotanPlugin;
-import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanBaseInterceptor;
 import com.megaease.easeagent.plugin.motan.interceptor.MotanCtxUtils;
-import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanTraceInterceptorTest;
+import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanBaseInterceptor;
+import com.megaease.easeagent.plugin.motan.interceptor.trace.MotanInterceptorTest;
 import com.megaease.easeagent.plugin.report.tracing.ReportSpan;
 import com.weibo.api.motan.rpc.Response;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(EaseAgentJunit4ClassRunner.class)
-public class MotanProviderTraceInterceptorTest extends MotanTraceInterceptorTest {
+public class MotanProviderInterceptorTest extends MotanInterceptorTest {
 
-    private MotanProviderTraceInterceptor motanProviderTraceInterceptor;
+    private static final MotanProviderTraceInterceptor motanProviderTraceInterceptor = new MotanProviderTraceInterceptor();
 
-
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        motanProviderTraceInterceptor = new MotanProviderTraceInterceptor();
-        InterceptorTestUtils.init(motanProviderTraceInterceptor, new MotanPlugin());
+    @Override
+    protected Interceptor createInterceptor() {
+        return motanProviderTraceInterceptor;
     }
 
 
@@ -49,7 +43,7 @@ public class MotanProviderTraceInterceptorTest extends MotanTraceInterceptorTest
     }
 
     @Test
-    public void init() {
+    public void testExternalConfig() {
         assertNotNull(MotanBaseInterceptor.MOTAN_PLUGIN_CONFIG);
         assertTrue(MotanBaseInterceptor.MOTAN_PLUGIN_CONFIG.argsCollectEnabled());
         assertTrue(MotanBaseInterceptor.MOTAN_PLUGIN_CONFIG.resultCollectEnabled());


### PR DESCRIPTION
- Change the label name `service` of the dubbo and motan plugins to `interface`.
- Refactor code
- Remove unnecessary unit tests

Closes #309