### PR TITLE
fix: jdbc4 plugin remoteServiceName

### DIFF
--- a/config/src/main/java/com/megaease/easeagent/config/ConfigFactory.java
+++ b/config/src/main/java/com/megaease/easeagent/config/ConfigFactory.java
@@ -95,6 +95,7 @@ public class ConfigFactory {
         // override by user special config file
         if (StringUtils.isNotEmpty(pathname)) {
             GlobalConfigs configsFromOuterFile = ConfigLoader.loadFromFile(new File(pathname));
+            LOGGER.info("Loaded user special config file: {}", pathname);
             configs.mergeConfigs(configsFromOuterFile);
         }
 

--- a/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/common/DatabaseInfo.java
+++ b/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/common/DatabaseInfo.java
@@ -28,6 +28,7 @@ import java.sql.SQLException;
 @Builder
 @Data
 public class DatabaseInfo {
+    private String databaseType;
     private String database;
     private String host;
     private int port;
@@ -36,14 +37,9 @@ public class DatabaseInfo {
         try {
             String jdbcURL = connection.getMetaData().getURL();
             URI url = URI.create(jdbcURL.substring(5)); // strip "jdbc:"
-            String remoteServiceName;
+            String remoteServiceName = url.getScheme(); // e.g. mysql, postgresql, oracle
             String databaseName = connection.getCatalog();
-            if (databaseName != null && !databaseName.isEmpty()) {
-                remoteServiceName = databaseName;
-            } else {
-                remoteServiceName = "";
-            }
-            return new DatabaseInfo(remoteServiceName,
+            return new DatabaseInfo(remoteServiceName, databaseName,
                 StringUtils.isNotEmpty(url.getHost()) ? url.getHost() : "",
                 url.getPort() == -1 ? 3306 : url.getPort());
         } catch (SQLException ignored) {

--- a/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptor.java
+++ b/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptor.java
@@ -34,7 +34,6 @@ import com.megaease.easeagent.plugin.interceptor.NonReentrantInterceptor;
 import com.megaease.easeagent.plugin.jdbc.JdbcTracingPlugin;
 import com.megaease.easeagent.plugin.jdbc.advice.JdbcStatementAdvice;
 import com.megaease.easeagent.plugin.jdbc.common.*;
-import com.megaease.easeagent.plugin.utils.common.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 
 import java.sql.Connection;
@@ -84,19 +83,20 @@ public class JdbcStmTracingInterceptor implements NonReentrantInterceptor {
         RedirectProcessor.setTagsIfRedirected(Redirect.DATABASE, span, url);
         DatabaseInfo databaseInfo = DatabaseInfo.getFromConnection(conn);
         if (databaseInfo != null) {
-            span.remoteServiceName(remoteServiceName(databaseInfo.getDatabase()));
+            span.remoteServiceName(remoteServiceName(databaseInfo));
             span.remoteIpAndPort(databaseInfo.getHost(), databaseInfo.getPort());
         }
         span.start();
         context.put(SPAN_KEY, span);
     }
 
-    public String remoteServiceName(String database) {
-        if (StringUtils.isEmpty(database)) {
-            return "mysql";
-        } else {
-            return "mysql-" + database;
-        }
+    public String remoteServiceName(DatabaseInfo info) {
+        return String.format("%s:%s", info.getDatabaseType(), info.getDatabase());
+//        if (StringUtils.isEmpty(info.getServiceName())) {
+//            return "mysql";
+//        } else {
+//            return "mysql-" + database;
+//        }
     }
 
     @Override

--- a/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptor.java
+++ b/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptor.java
@@ -91,7 +91,7 @@ public class JdbcStmTracingInterceptor implements NonReentrantInterceptor {
     }
 
     public String remoteServiceName(DatabaseInfo info) {
-        return String.format("%s:%s", info.getDatabaseType(), info.getDatabase());
+        return String.format("%s-%s", info.getDatabaseType(), info.getDatabase());
 //        if (StringUtils.isEmpty(info.getServiceName())) {
 //            return "mysql";
 //        } else {

--- a/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptor.java
+++ b/plugins/jdbc/src/main/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptor.java
@@ -92,11 +92,6 @@ public class JdbcStmTracingInterceptor implements NonReentrantInterceptor {
 
     public String remoteServiceName(DatabaseInfo info) {
         return String.format("%s-%s", info.getDatabaseType(), info.getDatabase());
-//        if (StringUtils.isEmpty(info.getServiceName())) {
-//            return "mysql";
-//        } else {
-//            return "mysql-" + database;
-//        }
     }
 
     @Override

--- a/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/TestUtils.java
+++ b/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/TestUtils.java
@@ -31,10 +31,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestUtils {
+    public static final String DATABASE_TYPE = "mysql";
     public static final String DATABASE = "db_damo";
     public static final String HOST = "192.168.1.14";
     public static final int PORT = 1234;
-    public static final String URI = String.format("jdbc:mysql://%s:%s/%s", HOST, PORT, DATABASE);
+    public static final String URI = String.format("jdbc:%s://%s:%s/%s", DATABASE_TYPE, HOST, PORT, DATABASE);
     public static final String FULL_URI = URI + "?useUnicode=true&characterEncoding=utf-8&autoReconnectForPools=true&autoReconnect=true";
     public static final String REDIRECT_USERNAME = "testUserName";
     public static final String REDIRECT_PASSWORD = "testPassword";

--- a/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/common/DatabaseInfoTest.java
+++ b/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/common/DatabaseInfoTest.java
@@ -33,6 +33,7 @@ public class DatabaseInfoTest {
         Connection connection = TestUtils.mockConnection();
         DatabaseInfo databaseInfo = DatabaseInfo.getFromConnection(connection);
         assertNotNull(databaseInfo);
+        assertEquals(TestUtils.DATABASE_TYPE, databaseInfo.getDatabaseType());
         assertEquals(TestUtils.DATABASE, databaseInfo.getDatabase());
         assertEquals(TestUtils.HOST, databaseInfo.getHost());
         assertEquals(TestUtils.PORT, databaseInfo.getPort());

--- a/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptorTest.java
+++ b/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptorTest.java
@@ -82,7 +82,7 @@ public class JdbcStmTracingInterceptorTest {
         assertEquals("database", reportSpan.tag(JdbcStmTracingInterceptor.SPAN_LOCAL_COMPONENT_TAG_NAME));
         assertEquals(TestUtils.URI, reportSpan.tag(JdbcStmTracingInterceptor.SPAN_URL));
         assertEquals(Type.DATABASE.getRemoteType(), reportSpan.tag(MiddlewareConstants.TYPE_TAG_NAME));
-        assertEquals(TestUtils.DATABASE_TYPE + ":" + TestUtils.DATABASE, reportSpan.remoteServiceName());
+        assertEquals(TestUtils.DATABASE_TYPE + "-" + TestUtils.DATABASE, reportSpan.remoteServiceName());
         assertEquals(TestUtils.HOST, reportSpan.remoteEndpoint().ipv4());
         assertEquals(TestUtils.PORT, reportSpan.remoteEndpoint().port());
 

--- a/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptorTest.java
+++ b/plugins/jdbc/src/test/java/com/megaease/easeagent/plugin/jdbc/interceptor/tracing/JdbcStmTracingInterceptorTest.java
@@ -82,7 +82,7 @@ public class JdbcStmTracingInterceptorTest {
         assertEquals("database", reportSpan.tag(JdbcStmTracingInterceptor.SPAN_LOCAL_COMPONENT_TAG_NAME));
         assertEquals(TestUtils.URI, reportSpan.tag(JdbcStmTracingInterceptor.SPAN_URL));
         assertEquals(Type.DATABASE.getRemoteType(), reportSpan.tag(MiddlewareConstants.TYPE_TAG_NAME));
-        assertEquals("mysql-" + TestUtils.DATABASE, reportSpan.remoteServiceName());
+        assertEquals(TestUtils.DATABASE_TYPE + ":" + TestUtils.DATABASE, reportSpan.remoteServiceName());
         assertEquals(TestUtils.HOST, reportSpan.remoteEndpoint().ipv4());
         assertEquals(TestUtils.PORT, reportSpan.remoteEndpoint().port());
 


### PR DESCRIPTION
Correct the issue of span.remoteServiceName in the JDBC plugin always being for MySQL. Modify it to be displayed based on the connection string, such as mysql:database_name, postgresql:database_name, oracle:database_name.