### PR TITLE
Fixes typo rebbitmq to rabbitmq

### DIFF
--- a/plugin-api/src/main/java/com/megaease/easeagent/plugin/api/trace/ITracing.java
+++ b/plugin-api/src/main/java/com/megaease/easeagent/plugin/api/trace/ITracing.java
@@ -88,7 +88,7 @@ public interface ITracing extends Tracing {
     List<String> propagationKeys();
 
     /**
-     * Obtain key:value from the message request and create a Span, Examples: kafka consumer, rebbitmq consumer
+     * Obtain key:value from the message request and create a Span, Examples: kafka consumer, rabbitmq consumer
      * <p>
      * It will set the Span's kind, name and cached scope through {@link Request#kind()}, {@link Request#name()}
      * and {@link Request#cacheScope()}.
@@ -109,7 +109,7 @@ public interface ITracing extends Tracing {
 
 
     /**
-     * Create a Span for message producer. Examples: kafka producer, rebbitmq producer
+     * Create a Span for message producer. Examples: kafka producer, rabbitmq producer
      * <p>
      * It will set the Span's tags "messaging.operation", "messaging.channel_kind", "messaging.channel_name" from request
      * {@link MessagingRequest#operation()} {@link MessagingRequest#channelKind()} {@link MessagingRequest#channelName()}

--- a/plugin-api/src/main/java/com/megaease/easeagent/plugin/api/trace/MessagingTracing.java
+++ b/plugin-api/src/main/java/com/megaease/easeagent/plugin/api/trace/MessagingTracing.java
@@ -69,7 +69,7 @@ public interface MessagingTracing<R extends MessagingRequest> {
     Function<R, Boolean> producerSampler();
 
     /**
-     * Obtain key:value from the message request and create a Span, Examples: kafka consumer, rebbitmq consumer
+     * Obtain key:value from the message request and create a Span, Examples: kafka consumer, rabbitmq consumer
      * <p>
      * It will set the Span's kind, name and cached scope through {@link Request#kind()}, {@link Request#name()}
      * and {@link Request#cacheScope()}.
@@ -90,7 +90,7 @@ public interface MessagingTracing<R extends MessagingRequest> {
 
 
     /**
-     * Create a Span for message producer. Examples: kafka producer, rebbitmq producer
+     * Create a Span for message producer. Examples: kafka producer, rabbitmq producer
      * <p>
      * It will set the Span's tags "messaging.operation", "messaging.channel_kind", "messaging.channel_name" from request
      * {@link MessagingRequest#operation()} {@link MessagingRequest#channelKind()} {@link MessagingRequest#channelName()}


### PR DESCRIPTION
Fixes typo `rebbitmq` to `rabbitmq` in module `plugin-api`