### PR TITLE
Fix: remove repeat argsLength matcher in MethodMatcherConvert

### DIFF
--- a/core/src/main/java/com/megaease/easeagent/core/plugin/matcher/MethodMatcherConvert.java
+++ b/core/src/main/java/com/megaease/easeagent/core/plugin/matcher/MethodMatcherConvert.java
@@ -116,11 +116,6 @@ public class MethodMatcherConvert
             }
         }
 
-        if (matcher.getArgsLength() >= 0) {
-            mc = takesArguments(matcher.getArgsLength());
-            c = c == null ? mc : c.and(mc);
-        }
-
         if (matcher.getOverriddenFrom() != null) {
             Junction<TypeDescription> cls = ClassMatcherConvert.INSTANCE.convert(matcher.getOverriddenFrom());
             mc = isOverriddenFrom(cls);


### PR DESCRIPTION
The removed code in `MethodMatcherConvert` duplicates lines 105-108. All of these lines check if `argsLength >= 0`, then pass the length to the Byte Buddy `takesArguments(int)` method.

This issue is highlighted in the test `com.megaease.easeagent.core.matcher.MethodMatcherTest#testMatcher`.

<img width="2956" height="1734" alt="MethodMatcherTest#testMatcher" src="https://github.com/user-attachments/assets/926b99bc-1c12-4cb0-819b-cadd6167b92f" />
